### PR TITLE
Log agent actions and reasoning for analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,15 @@ Run CLI to let CUA use a local browser window, using [playwright](https://playwr
 python cli.py --computer local-playwright
 ```
 
+### Analytics logging
+
+Every run of the CLI writes interaction analytics to a JSONL file under the
+`logs/` directory. Each user prompt and the model's subsequent actions (such as
+computer interactions, reasoning, and messages) are recorded along with timing
+information and any screenshots in base64 format. These logs can be used to
+compare the behaviour of multiple agents running in parallel or to perform
+custom analysis of agent activity.
+
 > [!NOTE]  
 > The first time you run this, if you haven't used Playwright before, you will be prompted to install dependencies. Execute the command suggested, which will depend on your OS.
 

--- a/analytics/__init__.py
+++ b/analytics/__init__.py
@@ -1,0 +1,3 @@
+from .logger import AnalyticsLogger
+
+__all__ = ["AnalyticsLogger"]

--- a/analytics/logger.py
+++ b/analytics/logger.py
@@ -1,0 +1,33 @@
+import os
+import uuid
+import json
+from datetime import datetime
+from typing import Any, Dict
+
+
+class AnalyticsLogger:
+    """Persist interaction events for later analysis.
+
+    Each run of the CLI creates a unique log file in JSON Lines format so that
+    multiple agents running in parallel do not clobber each other's data.
+    """
+
+    def __init__(self, log_dir: str = "logs"):
+        self.log_dir = log_dir
+        os.makedirs(self.log_dir, exist_ok=True)
+        run_ts = datetime.utcnow().strftime("%Y%m%dT%H%M%S")
+        self.run_id = f"{run_ts}_{uuid.uuid4()}"
+        self.log_path = os.path.join(self.log_dir, f"{self.run_id}.jsonl")
+
+    def log(self, record: Dict[str, Any]) -> None:
+        """Append a record to the log file."""
+        record["run_id"] = self.run_id
+        record.setdefault("timestamp", datetime.utcnow().isoformat())
+        with open(self.log_path, "a", encoding="utf-8") as f:
+            f.write(json.dumps(record) + "\n")
+
+    def new_prompt(self, content: str) -> str:
+        """Log a new user prompt and return its identifier."""
+        prompt_id = str(uuid.uuid4())
+        self.log({"type": "user_prompt", "prompt_id": prompt_id, "content": content})
+        return prompt_id

--- a/cli.py
+++ b/cli.py
@@ -3,6 +3,7 @@ from agent.agent import Agent
 from computers.config import *
 from computers.default import *
 from computers import computers_config
+from analytics.logger import AnalyticsLogger
 
 
 def acknowledge_safety_check_callback(message: str) -> bool:
@@ -46,11 +47,13 @@ def main():
     )
     args = parser.parse_args()
     ComputerClass = computers_config[args.computer]
+    logger = AnalyticsLogger()
 
     with ComputerClass() as computer:
         agent = Agent(
             computer=computer,
             acknowledge_safety_check_callback=acknowledge_safety_check_callback,
+            logger=logger,
         )
         items = []
 
@@ -67,12 +70,14 @@ def main():
             except EOFError as e:
                 print(f"An error occurred: {e}")
                 break
+            prompt_id = logger.new_prompt(user_input)
             items.append({"role": "user", "content": user_input})
             output_items = agent.run_full_turn(
                 items,
                 print_steps=True,
                 show_images=args.show,
                 debug=args.debug,
+                prompt_id=prompt_id,
             )
             items += output_items
             args.input = None


### PR DESCRIPTION
## Summary
- add AnalyticsLogger to persist prompts, actions and screenshots in per-run JSONL files
- log every agent thought and computer action with timing information
- expose logging through CLI and document the new analytics logs

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b0a9fea0c88331bf82b37cdf20004c