### PR TITLE
Log agent actions and reasoning for analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,22 @@ Run CLI to let CUA use a local browser window, using [playwright](https://playwr
 python cli.py --computer local-playwright
 ```
 
+### Analytics logging
+
+Each CLI run generates a unique **agent id** and stores interaction data in a
+structured format under `logs/<agent_id>/`:
+
+- `prompts.csv` – one row per user prompt with the prompt text.
+- `steps.csv` – one row per agent step. Columns include `agent_id`,
+  `prompt_id`, `step_id`, `step_type`, timing information, action details
+  (coordinates, button, typed text, etc.) and the filename of any screenshot.
+- `screenshots/` – base64-encoded images saved as `<step_id>.txt`. The
+  corresponding filenames are referenced in the `screenshot` column of
+  `steps.csv`.
+
+This structure makes it easy to analyse or compare the behaviour of multiple
+agents running in parallel.
+
 > [!NOTE]  
 > The first time you run this, if you haven't used Playwright before, you will be prompted to install dependencies. Execute the command suggested, which will depend on your OS.
 

--- a/analytics/__init__.py
+++ b/analytics/__init__.py
@@ -1,0 +1,3 @@
+from .logger import AnalyticsLogger
+
+__all__ = ["AnalyticsLogger"]

--- a/analytics/logger.py
+++ b/analytics/logger.py
@@ -1,0 +1,136 @@
+import os
+import uuid
+import csv
+import json
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+
+
+class AnalyticsLogger:
+    """Structured logger that stores prompts and steps for analytics.
+
+    Each run creates a unique directory containing two CSV files:
+    - ``prompts.csv``: one row per user prompt
+    - ``steps.csv``: one row per agent step triggered by a prompt
+
+    Screenshots are stored as separate ``.txt`` files containing the
+    base64-encoded image. The corresponding filename is referenced in the
+    ``screenshot`` column of ``steps.csv``.
+    """
+
+    prompt_fields = ["agent_id", "prompt_id", "prompt", "timestamp"]
+    step_fields = [
+        "agent_id",
+        "prompt_id",
+        "step_id",
+        "step_type",
+        "action_type",
+        "role",
+        "text",
+        "button",
+        "x",
+        "y",
+        "call_id",
+        "screenshot",
+        "timestamp",
+        "duration",
+        "details",
+    ]
+
+    def __init__(self, log_dir: str = "logs") -> None:
+        self.base_dir = log_dir
+        os.makedirs(self.base_dir, exist_ok=True)
+        run_ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S")
+        self.agent_id = f"{run_ts}_{uuid.uuid4()}"
+        self.run_dir = os.path.join(self.base_dir, self.agent_id)
+        self.screenshot_dir = os.path.join(self.run_dir, "screenshots")
+        os.makedirs(self.screenshot_dir, exist_ok=True)
+
+        self.prompts_path = os.path.join(self.run_dir, "prompts.csv")
+        self.steps_path = os.path.join(self.run_dir, "steps.csv")
+
+        # Initialize CSV files with headers
+        with open(self.prompts_path, "w", newline="", encoding="utf-8") as f:
+            csv.writer(f).writerow(self.prompt_fields)
+        with open(self.steps_path, "w", newline="", encoding="utf-8") as f:
+            csv.writer(f).writerow(self.step_fields)
+
+    def new_prompt(self, content: str) -> str:
+        """Record a user prompt and return its identifier."""
+        prompt_id = str(uuid.uuid4())
+        timestamp = datetime.now(timezone.utc).isoformat()
+        with open(self.prompts_path, "a", newline="", encoding="utf-8") as f:
+            writer = csv.writer(f)
+            writer.writerow([self.agent_id, prompt_id, content, timestamp])
+        return prompt_id
+
+    def log_step(
+        self,
+        prompt_id: str,
+        step_type: str,
+        duration: float,
+        **data: Any,
+    ) -> str:
+        """Log a step taken by the agent.
+
+        Args:
+            prompt_id: ID of the prompt that triggered this step.
+            step_type: The kind of item (e.g., "message", "computer_call").
+            duration: Time taken in seconds.
+            **data: Additional structured information about the step. Any
+                unrecognized keys will be stored as JSON in the ``details``
+                column.
+        Returns:
+            The generated step identifier.
+        """
+        step_id = str(uuid.uuid4())
+        timestamp = datetime.now(timezone.utc).isoformat()
+
+        screenshot_file = ""
+        screenshot_b64: Optional[str] = data.pop("screenshot", None)
+        if screenshot_b64:
+            screenshot_file = f"{step_id}.txt"
+            with open(
+                os.path.join(self.screenshot_dir, screenshot_file),
+                "w",
+                encoding="utf-8",
+            ) as img_file:
+                img_file.write(screenshot_b64)
+
+        known_fields = {
+            "action_type",
+            "role",
+            "text",
+            "button",
+            "x",
+            "y",
+            "call_id",
+        }
+        row: Dict[str, Any] = {
+            "agent_id": self.agent_id,
+            "prompt_id": prompt_id,
+            "step_id": step_id,
+            "step_type": step_type,
+            "screenshot": screenshot_file,
+            "timestamp": timestamp,
+            "duration": duration,
+        }
+
+        extras = {}
+        for key, value in data.items():
+            if key in known_fields:
+                row[key] = value
+            else:
+                extras[key] = value
+
+        # Ensure all known fields exist even if None
+        for field in known_fields:
+            row.setdefault(field, "")
+
+        row["details"] = json.dumps(extras) if extras else ""
+
+        with open(self.steps_path, "a", newline="", encoding="utf-8") as f:
+            writer = csv.DictWriter(f, fieldnames=self.step_fields)
+            writer.writerow(row)
+
+        return step_id

--- a/cli.py
+++ b/cli.py
@@ -3,6 +3,7 @@ from agent.agent import Agent
 from computers.config import *
 from computers.default import *
 from computers import computers_config
+from analytics.logger import AnalyticsLogger
 
 
 def acknowledge_safety_check_callback(message: str) -> bool:
@@ -46,11 +47,14 @@ def main():
     )
     args = parser.parse_args()
     ComputerClass = computers_config[args.computer]
+    logger = AnalyticsLogger()
+    print(f"Agent ID: {logger.agent_id}")
 
     with ComputerClass() as computer:
         agent = Agent(
             computer=computer,
             acknowledge_safety_check_callback=acknowledge_safety_check_callback,
+            logger=logger,
         )
         items = []
 
@@ -67,12 +71,14 @@ def main():
             except EOFError as e:
                 print(f"An error occurred: {e}")
                 break
+            prompt_id = logger.new_prompt(user_input)
             items.append({"role": "user", "content": user_input})
             output_items = agent.run_full_turn(
                 items,
                 print_steps=True,
                 show_images=args.show,
                 debug=args.debug,
+                prompt_id=prompt_id,
             )
             items += output_items
             args.input = None

--- a/tests/test_analytics_logger.py
+++ b/tests/test_analytics_logger.py
@@ -1,0 +1,38 @@
+import csv
+from analytics import AnalyticsLogger
+
+
+def test_structured_logging(tmp_path):
+    log_dir = tmp_path / "logs"
+    logger = AnalyticsLogger(log_dir=str(log_dir))
+
+    # Prompt logging
+    prompt_id = logger.new_prompt("hello")
+    prompts_path = log_dir / logger.agent_id / "prompts.csv"
+    with open(prompts_path, newline="", encoding="utf-8") as f:
+        rows = list(csv.DictReader(f))
+    assert rows[0]["prompt_id"] == prompt_id
+    assert rows[0]["prompt"] == "hello"
+
+    # Step logging with screenshot
+    step_id = logger.log_step(
+        prompt_id,
+        "computer_call",
+        0.5,
+        action_type="click",
+        x=1,
+        y=2,
+        button="left",
+        screenshot="abc123",
+    )
+    steps_path = log_dir / logger.agent_id / "steps.csv"
+    with open(steps_path, newline="", encoding="utf-8") as f:
+        rows = list(csv.DictReader(f))
+    assert rows[0]["step_id"] == step_id
+    assert rows[0]["x"] == "1"
+    assert rows[0]["y"] == "2"
+    assert rows[0]["button"] == "left"
+    assert rows[0]["screenshot"] == f"{step_id}.txt"
+
+    screenshot_file = log_dir / logger.agent_id / "screenshots" / f"{step_id}.txt"
+    assert screenshot_file.read_text() == "abc123"


### PR DESCRIPTION
## Summary
- store prompts and steps in structured CSV logs with per-run agent IDs
- capture detailed step metadata and screenshot filenames via new AnalyticsLogger
- expose agent ID in CLI and document structured analytics logging

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b0a9fea0c88331bf82b37cdf20004c