### PR TITLE
Add structured analytics log export

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ information and any screenshots in base64 format. These logs can be used to
 compare the behaviour of multiple agents running in parallel or to perform
 custom analysis of agent activity.
 
+The helper function `analytics.build_structured_table()` converts a log file
+into a structured CSV table. Screenshots are extracted to image files and the
+table captures the agent, prompt and step identifiers along with action details
+such as click coordinates or typed text.
+
 > [!NOTE]  
 > The first time you run this, if you haven't used Playwright before, you will be prompted to install dependencies. Execute the command suggested, which will depend on your OS.
 

--- a/analytics/__init__.py
+++ b/analytics/__init__.py
@@ -1,3 +1,4 @@
 from .logger import AnalyticsLogger
+from .structured_table import build_structured_table
 
-__all__ = ["AnalyticsLogger"]
+__all__ = ["AnalyticsLogger", "build_structured_table"]

--- a/analytics/logger.py
+++ b/analytics/logger.py
@@ -16,12 +16,15 @@ class AnalyticsLogger:
         self.log_dir = log_dir
         os.makedirs(self.log_dir, exist_ok=True)
         run_ts = datetime.utcnow().strftime("%Y%m%dT%H%M%S")
-        self.run_id = f"{run_ts}_{uuid.uuid4()}"
-        self.log_path = os.path.join(self.log_dir, f"{self.run_id}.jsonl")
+        # Unique identifier for a single agent session.
+        self.agent_id = f"{run_ts}_{uuid.uuid4()}"
+        self.log_path = os.path.join(self.log_dir, f"{self.agent_id}.jsonl")
 
     def log(self, record: Dict[str, Any]) -> None:
         """Append a record to the log file."""
-        record["run_id"] = self.run_id
+        # Persist the agent identifier on every record so logs can be
+        # correlated later.
+        record["agent_id"] = self.agent_id
         record.setdefault("timestamp", datetime.utcnow().isoformat())
         with open(self.log_path, "a", encoding="utf-8") as f:
             f.write(json.dumps(record) + "\n")

--- a/analytics/structured_table.py
+++ b/analytics/structured_table.py
@@ -1,0 +1,117 @@
+import os
+import json
+import csv
+import base64
+from typing import Dict, Any
+
+def build_structured_table(log_path: str, output_csv: str | None = None, image_dir: str | None = None) -> str:
+    """Convert a JSONL log file to a structured CSV table.
+
+    Screenshots in the log are written to ``image_dir`` and the filename is
+    recorded in the ``Screenshot`` column of the CSV. Each row represents a
+    step in a prompt run and contains identifiers for the agent, prompt and
+    step along with action details.
+
+    Parameters
+    ----------
+    log_path: str
+        Path to the JSON Lines log file produced by ``AnalyticsLogger``.
+    output_csv: str, optional
+        Destination path for the structured CSV. Defaults to the same name as
+        ``log_path`` with ``.csv`` extension.
+    image_dir: str, optional
+        Directory where extracted screenshots will be written. Defaults to a
+        sibling of ``log_path`` with ``_images`` suffix.
+
+    Returns
+    -------
+    str
+        The path to the generated CSV file.
+    """
+
+    if output_csv is None:
+        output_csv = os.path.splitext(log_path)[0] + ".csv"
+    if image_dir is None:
+        image_dir = os.path.splitext(log_path)[0] + "_images"
+    os.makedirs(image_dir, exist_ok=True)
+
+    step_counters: Dict[str, int] = {}
+    rows: list[Dict[str, Any]] = []
+
+    with open(log_path, "r", encoding="utf-8") as f:
+        for line in f:
+            record = json.loads(line)
+            agent_id = record.get("agent_id") or record.get("run_id")
+            prompt_id = record.get("prompt_id")
+            record_type = record.get("type")
+            timestamp = record.get("timestamp")
+            duration = record.get("duration")
+            screenshot_file = ""
+            action_type = ""
+            x = ""
+            y = ""
+            text = ""
+
+            if record_type == "user_prompt":
+                step_id = 0
+                text = record.get("content", "")
+            else:
+                step_id = step_counters.get(prompt_id, 0) + 1
+                step_counters[prompt_id] = step_id
+                action = record.get("action", {})
+                action_type = action.get("type", record.get("name", ""))
+                x = action.get("x", "")
+                y = action.get("y", "")
+                if action_type == "type":
+                    text = action.get("text", "")
+                elif record_type == "message":
+                    content = record.get("content", [])
+                    if isinstance(content, list):
+                        text = " ".join(part.get("text", "") for part in content if isinstance(part, dict))
+                    else:
+                        text = str(content)
+                elif record_type == "reasoning":
+                    text = record.get("summary", "")
+
+                if "screenshot" in record:
+                    image_bytes = base64.b64decode(record["screenshot"])
+                    screenshot_file = f"{prompt_id}_{step_id}.png"
+                    with open(os.path.join(image_dir, screenshot_file), "wb") as img_f:
+                        img_f.write(image_bytes)
+
+            rows.append(
+                {
+                    "Agent_Id": agent_id,
+                    "Prompt_Id": prompt_id,
+                    "Step_Id": step_id,
+                    "Type": record_type,
+                    "Action": action_type,
+                    "X": x,
+                    "Y": y,
+                    "Text": text,
+                    "Duration": duration,
+                    "Timestamp": timestamp,
+                    "Screenshot": screenshot_file,
+                }
+            )
+
+    fieldnames = [
+        "Agent_Id",
+        "Prompt_Id",
+        "Step_Id",
+        "Type",
+        "Action",
+        "X",
+        "Y",
+        "Text",
+        "Duration",
+        "Timestamp",
+        "Screenshot",
+    ]
+
+    with open(output_csv, "w", encoding="utf-8", newline="") as csvfile:
+        writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+    return output_csv

--- a/tests/test_structured_logging.py
+++ b/tests/test_structured_logging.py
@@ -1,0 +1,53 @@
+import csv
+from pathlib import Path
+
+from analytics import AnalyticsLogger, build_structured_table
+
+# 1x1 transparent PNG
+PIXEL_BASE64 = (
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8z/C/HwAF/gL+VkC4XAAAAABJRU5ErkJggg=="
+)
+
+
+def test_build_structured_table(tmp_path: Path) -> None:
+    log_dir = tmp_path / "logs"
+    logger = AnalyticsLogger(log_dir=str(log_dir))
+    prompt_id = logger.new_prompt("hello")
+    logger.log(
+        {
+            "prompt_id": prompt_id,
+            "type": "computer_call",
+            "action": {"type": "click", "x": 1, "y": 2},
+            "screenshot": PIXEL_BASE64,
+            "duration": 0.5,
+        }
+    )
+    logger.log(
+        {
+            "prompt_id": prompt_id,
+            "type": "message",
+            "role": "assistant",
+            "content": [{"text": "done"}],
+            "duration": 0.1,
+        }
+    )
+
+    log_file = next(log_dir.glob("*.jsonl"))
+    out_csv = tmp_path / "structured.csv"
+    build_structured_table(str(log_file), str(out_csv))
+
+    assert out_csv.exists()
+    with open(out_csv, newline="", encoding="utf-8") as f:
+        rows = list(csv.DictReader(f))
+
+    # Expect three rows: user prompt + two steps
+    assert len(rows) == 3
+    prompt_rows = [r for r in rows if r["Prompt_Id"] == prompt_id]
+    assert prompt_rows[0]["Step_Id"] == "0"
+    assert prompt_rows[1]["Step_Id"] == "1"
+    # Ensure screenshot was extracted
+    screenshot_file = prompt_rows[1]["Screenshot"]
+    assert screenshot_file
+    image_dir = Path(str(log_file).replace(".jsonl", "_images"))
+    image_path = image_dir / screenshot_file
+    assert image_path.exists()


### PR DESCRIPTION
## Summary
- assign a unique `agent_id` to each logging session
- add `build_structured_table` helper to turn JSONL logs into CSV and extract screenshots
- document structured log export and cover it with tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b0c9b907b08331a896c00e787e11a8