### PR TITLE
Replace union types with Optional for Python 3.9 compatibility

### DIFF
--- a/computers/default/scrapybara.py
+++ b/computers/default/scrapybara.py
@@ -1,8 +1,10 @@
 import os
 import time
+from typing import Optional
+
 from dotenv import load_dotenv
 from scrapybara import Scrapybara
-from playwright.sync_api import sync_playwright, Browser, Page
+from playwright.sync_api import Browser, Page, sync_playwright
 from utils import BLOCKED_DOMAINS
 
 load_dotenv()
@@ -46,8 +48,8 @@ class ScrapybaraBrowser:
     def __init__(self):
         self.client = Scrapybara(api_key=os.getenv("SCRAPYBARA_API_KEY"))
         self._playwright = None
-        self._browser: Browser | None = None
-        self._page: Page | None = None
+        self._browser: Optional[Browser] = None
+        self._page: Optional[Page] = None
 
     def __enter__(self):
         print("Starting scrapybara browser")

--- a/computers/shared/base_playwright.py
+++ b/computers/shared/base_playwright.py
@@ -1,7 +1,8 @@
 import time
 import base64
-from typing import List, Dict, Literal
-from playwright.sync_api import sync_playwright, Browser, Page
+from typing import Dict, List, Literal, Optional
+
+from playwright.sync_api import Browser, Page, sync_playwright
 from utils import check_blocklisted_url
 
 # Optional: key mapping if your model uses "CUA" style keys
@@ -53,8 +54,8 @@ class BasePlaywrightComputer:
 
     def __init__(self):
         self._playwright = None
-        self._browser: Browser | None = None
-        self._page: Page | None = None
+        self._browser: Optional[Browser] = None
+        self._page: Optional[Page] = None
 
     def __enter__(self):
         # Start Playwright and call the subclass hook for getting browser/page


### PR DESCRIPTION
## Summary
- Import `Optional` and switch to `Optional[Browser]`/`Optional[Page]` in Scrapybara browser wrapper
- Use `Optional` type hints in BasePlaywright computer

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0d2073378833194a5988239f292eb