### PR TITLE
Organize logs by agent session

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,17 +23,20 @@ python cli.py --computer local-playwright
 
 ### Analytics logging
 
-Every run of the CLI writes interaction analytics to a JSONL file under the
-`logs/` directory. Each user prompt and the model's subsequent actions (such as
-computer interactions, reasoning, and messages) are recorded along with timing
-information and any screenshots in base64 format. These logs can be used to
-compare the behaviour of multiple agents running in parallel or to perform
-custom analysis of agent activity.
+Every run of the CLI writes interaction analytics to a unique subdirectory
+under the `logs/` directory named after the agent identifier. This folder
+contains a `log.jsonl` file for raw events, a `steps.csv` table and a
+`screenshots/` subdirectory. Each user prompt and the model's subsequent actions
+(such as computer interactions, reasoning, and messages) are recorded along
+with timing information and any screenshots in base64 format. These logs can be
+used to compare the behaviour of multiple agents running in parallel or to
+perform custom analysis of agent activity.
 
 The helper function `analytics.build_structured_table()` converts a log file
-into a structured CSV table. Screenshots are extracted to image files and the
-table captures the agent, prompt and step identifiers along with action details
-such as click coordinates or typed text.
+into the `steps.csv` table and writes extracted screenshots to the
+`screenshots/` directory by default. The table captures the agent, prompt and
+step identifiers along with action details such as click coordinates or typed
+text.
 
 > [!NOTE]  
 > The first time you run this, if you haven't used Playwright before, you will be prompted to install dependencies. Execute the command suggested, which will depend on your OS.

--- a/analytics/logger.py
+++ b/analytics/logger.py
@@ -8,8 +8,10 @@ from typing import Any, Dict
 class AnalyticsLogger:
     """Persist interaction events for later analysis.
 
-    Each run of the CLI creates a unique log file in JSON Lines format so that
-    multiple agents running in parallel do not clobber each other's data.
+    Each run of the CLI creates a unique directory under ``log_dir`` named
+    after the agent identifier. This ensures that multiple agents running in
+    parallel do not clobber each other's data and keeps related artifacts
+    (log file, CSV table, screenshots) together.
     """
 
     def __init__(self, log_dir: str = "logs"):
@@ -18,7 +20,11 @@ class AnalyticsLogger:
         run_ts = datetime.utcnow().strftime("%Y%m%dT%H%M%S")
         # Unique identifier for a single agent session.
         self.agent_id = f"{run_ts}_{uuid.uuid4()}"
-        self.log_path = os.path.join(self.log_dir, f"{self.agent_id}.jsonl")
+        # Directory dedicated to this agent's run.
+        self.agent_dir = os.path.join(self.log_dir, self.agent_id)
+        os.makedirs(self.agent_dir, exist_ok=True)
+        # JSONL log for the agent's interaction events.
+        self.log_path = os.path.join(self.agent_dir, "log.jsonl")
 
     def log(self, record: Dict[str, Any]) -> None:
         """Append a record to the log file."""

--- a/analytics/structured_table.py
+++ b/analytics/structured_table.py
@@ -21,11 +21,11 @@ def build_structured_table(
     log_path: str
         Path to the JSON Lines log file produced by ``AnalyticsLogger``.
     output_csv: str, optional
-        Destination path for the structured CSV. Defaults to the same name as
-        ``log_path`` with ``.csv`` extension.
+        Destination path for the structured CSV. Defaults to ``steps.csv``
+        in the same directory as ``log_path``.
     image_dir: str, optional
         Directory where extracted screenshots will be written. Defaults to a
-        sibling of ``log_path`` with ``_images`` suffix.
+        ``screenshots`` subdirectory next to ``log_path``.
 
     Returns
     -------
@@ -33,10 +33,11 @@ def build_structured_table(
         The path to the generated CSV file.
     """
 
+    log_dir = os.path.dirname(log_path)
     if output_csv is None:
-        output_csv = os.path.splitext(log_path)[0] + ".csv"
+        output_csv = os.path.join(log_dir, "steps.csv")
     if image_dir is None:
-        image_dir = os.path.splitext(log_path)[0] + "_images"
+        image_dir = os.path.join(log_dir, "screenshots")
     os.makedirs(image_dir, exist_ok=True)
 
     step_counters: Dict[str, int] = {}

--- a/tests/test_structured_logging.py
+++ b/tests/test_structured_logging.py
@@ -32,11 +32,10 @@ def test_build_structured_table(tmp_path: Path) -> None:
         }
     )
 
-    log_file = next(log_dir.glob("*.jsonl"))
-    out_csv = tmp_path / "structured.csv"
-    build_structured_table(str(log_file), str(out_csv))
+    log_file = log_dir / logger.agent_id / "log.jsonl"
+    out_csv = build_structured_table(str(log_file))
 
-    assert out_csv.exists()
+    assert Path(out_csv).exists()
     with open(out_csv, newline="", encoding="utf-8") as f:
         rows = list(csv.DictReader(f))
 
@@ -48,6 +47,6 @@ def test_build_structured_table(tmp_path: Path) -> None:
     # Ensure screenshot was extracted
     screenshot_file = prompt_rows[1]["Screenshot"]
     assert screenshot_file
-    image_dir = Path(str(log_file).replace(".jsonl", "_images"))
+    image_dir = log_dir / logger.agent_id / "screenshots"
     image_path = image_dir / screenshot_file
     assert image_path.exists()


### PR DESCRIPTION
## Summary
- create a per-agent log directory containing `log.jsonl`
- default structured table output to `steps.csv` and `screenshots/` within the agent directory
- document and test new log layout

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b43cb88b68833186c296c02859be13