### PR TITLE
Add configurable step ceiling to agent loops

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -46,6 +46,12 @@ def main():
         help="Start the browsing session with a specific URL (only for browser environments).",
         default="https://bing.com",
     )
+    parser.add_argument(
+        "--max-steps",
+        type=int,
+        help="Maximum number of model round trips to run before returning a capped response.",
+        default=None,
+    )
     args = parser.parse_args()
     ComputerClass = computers_config[args.computer]
 
@@ -78,6 +84,7 @@ def main():
                 show_images=args.show,
                 debug=args.debug,
                 prompt_id=prompt_id,
+                max_steps=args.max_steps,
             )
             items += output_items
             args.input = None


### PR DESCRIPTION
## Summary
- add a --max-steps flag to the CLI and propagate it through Agent.run_full_turn
- enforce the optional step ceiling inside Agent.run_full_turn with a synthetic assistant message when reached
- mirror the optional step limit inside simple_cua_loop.py

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d40e30a1048331bf44e5d267c7eb27