### PR TITLE
Log browser metadata for local Playwright CLI sessions

### DIFF
--- a/agent/agent.py
+++ b/agent/agent.py
@@ -117,7 +117,21 @@ class Agent:
             if self.computer.get_environment() == "browser":
                 current_url = self.computer.get_current_url()
                 check_blocklisted_url(current_url)
-                call_output["output"]["current_url"] = current_url
+
+                metadata = {}
+                get_metadata = getattr(self.computer, "get_page_metadata", None)
+                if callable(get_metadata):
+                    metadata = get_metadata() or {}
+
+                if not metadata.get("full_url"):
+                    metadata["full_url"] = current_url
+
+                call_output["output"]["current_url"] = metadata.get("full_url", current_url)
+                if metadata:
+                    call_output["output"]["page_metadata"] = metadata
+                    record["page_metadata"] = metadata
+                else:
+                    record["current_url"] = current_url
 
             output_items = [call_output]
             record.update(

--- a/cli.py
+++ b/cli.py
@@ -67,6 +67,18 @@ def main():
             if not args.start_url.startswith("http"):
                 args.start_url = "https://" + args.start_url
             agent.computer.goto(args.start_url)
+            get_metadata = getattr(agent.computer, "get_page_metadata", None)
+            if callable(get_metadata):
+                metadata = get_metadata() or {}
+                if not metadata.get("full_url"):
+                    metadata["full_url"] = agent.computer.get_current_url()
+                logger.log(
+                    {
+                        "type": "browser_state",
+                        "event": "initial_navigation",
+                        "metadata": metadata,
+                    }
+                )
 
         while True:
             try:


### PR DESCRIPTION
## Summary
- add a Playwright helper for extracting page metadata such as URLs, title, and referrer
- record browser metadata in CLI logs during initial navigation when using local Playwright
- enrich per-step agent logs with page metadata for browser computer calls

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d428f0f9488331bdf827f57c94d721