### PR TITLE
Capture browser metadata in structured CSV output

### DIFF
--- a/analytics/structured_table.py
+++ b/analytics/structured_table.py
@@ -74,6 +74,23 @@ def build_structured_table(
             y = ""
             text = ""
 
+            metadata: Dict[str, Any] = {}
+            # Browser metadata can be stored on different keys depending on the
+            # event type. Prefer the rich ``page_metadata`` payload emitted from
+            # computer actions, then fall back to more generic metadata or the
+            # current URL if present.
+            if isinstance(record.get("page_metadata"), dict):
+                metadata = record["page_metadata"]
+            elif isinstance(record.get("metadata"), dict):
+                metadata = record["metadata"]
+
+            current_url = metadata.get("full_url") or record.get("current_url", "")
+            page_title = metadata.get("page_title", "")
+            domain = metadata.get("domain", "")
+            path = metadata.get("path", "")
+            short_url = metadata.get("short_url", "")
+            referrer = metadata.get("referrer", "")
+
             if record_type == "user_prompt":
                 step_id = 0
                 text = record.get("content", "")
@@ -114,6 +131,12 @@ def build_structured_table(
                     "Duration": duration,
                     "Timestamp": timestamp,
                     "Screenshot": screenshot_file,
+                    "URL": current_url,
+                    "Page_Title": page_title,
+                    "Domain": domain,
+                    "Path": path,
+                    "Short_URL": short_url,
+                    "Referrer": referrer,
                 }
             )
 
@@ -129,6 +152,12 @@ def build_structured_table(
         "Duration",
         "Timestamp",
         "Screenshot",
+        "URL",
+        "Page_Title",
+        "Domain",
+        "Path",
+        "Short_URL",
+        "Referrer",
     ]
 
     with open(output_csv, "w", encoding="utf-8", newline="") as csvfile:

--- a/tests/test_structured_logging.py
+++ b/tests/test_structured_logging.py
@@ -21,6 +21,11 @@ def test_build_structured_table(tmp_path: Path) -> None:
             "action": {"type": "click", "x": 1, "y": 2},
             "screenshot": PIXEL_BASE64,
             "duration": 0.5,
+            "page_metadata": {
+                "full_url": "https://example.com/",
+                "page_title": "Example Domain",
+                "domain": "example.com",
+            },
         }
     )
     logger.log(
@@ -45,6 +50,9 @@ def test_build_structured_table(tmp_path: Path) -> None:
     prompt_rows = [r for r in rows if r["Prompt_Id"] == prompt_id]
     assert prompt_rows[0]["Step_Id"] == "0"
     assert prompt_rows[1]["Step_Id"] == "1"
+    assert prompt_rows[1]["URL"] == "https://example.com/"
+    assert prompt_rows[1]["Page_Title"] == "Example Domain"
+    assert prompt_rows[1]["Domain"] == "example.com"
     # Ensure screenshot was extracted
     screenshot_file = prompt_rows[1]["Screenshot"]
     assert screenshot_file


### PR DESCRIPTION
## Summary
- include browser metadata such as URL, page title, and domain when building the structured CSV
- add corresponding CSV columns so navigation context is captured for each step
- update structured logging tests to cover the new metadata columns

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d44d2323448331887735da6df2639c