### PR TITLE
Add CLI option to exit after assistant message

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ The CLI (`cli.py`) is the easiest way to get started with CUA. It accepts the fo
 - `--debug`: Enable debug mode.
 - `--show`: Show images (screenshots) during the execution.
 - `--start-url`: Start the browsing session with a specific URL (only for browser environments). By default, the CLI will start the browsing session with `https://bing.com`.
+- `--stop-on-message`: Immediately stop the session after the assistant returns a message to the user.
 
 ### Run examples (optional)
 

--- a/cli.py
+++ b/cli.py
@@ -52,6 +52,14 @@ def main():
         help="Maximum number of model round trips to run before returning a capped response.",
         default=None,
     )
+    parser.add_argument(
+        "--stop-on-message",
+        action="store_true",
+        help=(
+            "Stop the agent automatically once it produces a message for the user. "
+            "Useful for terminating the session after the first assistant reply."
+        ),
+    )
     args = parser.parse_args()
     ComputerClass = computers_config[args.computer]
 
@@ -100,6 +108,13 @@ def main():
             )
             items += output_items
             args.input = None
+
+            if args.stop_on_message and any(
+                item.get("type") == "message" and item.get("role") == "assistant"
+                for item in output_items
+            ):
+                print("Assistant message received; stopping due to --stop-on-message.")
+                break
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add a --stop-on-message flag to the CLI to exit once the assistant produces a message
- document the new flag in the README so the workflow is discoverable

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d684ab0bb8833199ced195a13c850c