### PR TITLE
Log max step limit with dedicated type

### DIFF
--- a/agent/agent.py
+++ b/agent/agent.py
@@ -57,7 +57,7 @@ class Agent:
         record = {"prompt_id": self.current_prompt_id, "type": item.get("type")}
         output_items = []
 
-        if item["type"] == "message":
+        if item["type"] in {"message", "max-steps"}:
             if self.print_steps:
                 print(item["content"][0]["text"])
             record["role"] = item.get("role")
@@ -176,7 +176,7 @@ class Agent:
 
             if max_steps is not None and step_count >= max_steps:
                 limit_message = {
-                    "type": "message",
+                    "type": "max-steps",
                     "role": "assistant",
                     "content": [
                         {

--- a/simple_cua_loop.py
+++ b/simple_cua_loop.py
@@ -14,7 +14,7 @@ def acknowledge_safety_check_callback(message: str) -> bool:
 
 def handle_item(item, computer: Computer):
     """Handle each item; may cause a computer action + screenshot."""
-    if item["type"] == "message":  # print messages
+    if item["type"] in {"message", "max-steps"}:  # print messages
         print(item["content"][0]["text"])
 
     if item["type"] == "computer_call":  # perform computer actions
@@ -89,7 +89,7 @@ def main():
 
                 if args.max_steps is not None and step_count >= args.max_steps:
                     limit_message = {
-                        "type": "message",
+                        "type": "max-steps",
                         "role": "assistant",
                         "content": [
                             {


### PR DESCRIPTION
## Summary
- log capped runs as a dedicated `max-steps` record in both the agent and simple loop
- allow handlers to print max-step notifications the same way as regular messages

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d68df309208331ac2e5b5cf5f17e81