### PR TITLE
Align analytics logs with agent pool IDs

### DIFF
--- a/analytics/logger.py
+++ b/analytics/logger.py
@@ -2,7 +2,7 @@ import os
 import uuid
 import json
 from datetime import datetime
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 
 class AnalyticsLogger:
@@ -14,12 +14,20 @@ class AnalyticsLogger:
     (log file, CSV table, screenshots) together.
     """
 
-    def __init__(self, log_dir: str = "logs"):
+    def __init__(self, log_dir: str = "logs", agent_id: Optional[str] = None):
         self.log_dir = log_dir
         os.makedirs(self.log_dir, exist_ok=True)
         run_ts = datetime.utcnow().strftime("%Y%m%dT%H%M%S")
+        # Allow the caller to supply an explicit agent identifier so that
+        # external orchestrators (e.g. the agent pool) can coordinate ids
+        # across different logging sinks. Fall back to an environment variable
+        # for convenience, and finally generate a fresh identifier when nothing
+        # is provided.
+        provided_agent_id = agent_id or os.getenv("CUA_AGENT_ID")
+        if provided_agent_id:
+            provided_agent_id = os.path.basename(os.path.normpath(provided_agent_id))
         # Unique identifier for a single agent session.
-        self.agent_id = f"{run_ts}_{uuid.uuid4()}"
+        self.agent_id = provided_agent_id or f"{run_ts}_{uuid.uuid4()}"
         # Directory dedicated to this agent's run.
         self.agent_dir = os.path.join(self.log_dir, self.agent_id)
         os.makedirs(self.agent_dir, exist_ok=True)

--- a/tests/test_structured_logging.py
+++ b/tests/test_structured_logging.py
@@ -1,5 +1,6 @@
 import csv
 import json
+import os
 from pathlib import Path
 
 from analytics import AnalyticsLogger, build_structured_table
@@ -99,3 +100,15 @@ def test_build_structured_table_creates_agent_scoped_screenshots(tmp_path: Path)
     assert scoped_dir.exists()
     assert (scoped_dir / f"{prompt_id}_1.png").exists()
     assert not (log_dir / "screenshots").exists()
+
+
+def test_logger_uses_env_agent_id(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("CUA_AGENT_ID", "custom/agent")
+    log_dir = tmp_path / "logs"
+    logger = AnalyticsLogger(log_dir=str(log_dir))
+
+    assert logger.agent_id == "agent"
+    expected_dir = log_dir / "agent"
+    assert logger.agent_dir == os.path.join(str(log_dir), "agent")
+    assert expected_dir.exists()
+    assert logger.log_path == os.path.join(str(expected_dir), "log.jsonl")


### PR DESCRIPTION
## Summary
- propagate the agent pool run identifier into spawned processes so analytics logs share the same id
- allow AnalyticsLogger to respect a provided or environment-specified agent id before falling back to a generated value
- cover the new environment override behavior with a regression test

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d6b9f2c3b0833182fdd54e5ccdc56e